### PR TITLE
fix: binding to `picard-web` clearing folder build time config

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -13,33 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-create_directory_if_missing(){
-    if [ ! -d "$1" ]; then
-        mkdir -p "$1"
-        chown $PUID:$PGID "$1"
+for dir in /pw/initial/*/; do
+    dir=$(basename "$dir")
+    if [ ! -d "/picard-web/$dir" ]; then
+        mkdir -p "/picard-web/$dir"
+        cp -a "/pw/initial/$dir/." "/picard-web/$dir/"
+        chown -R "$PUID:$PGID" "/picard-web/$dir"
     fi
-}
-
-# Create folder for backups
-create_directory_if_missing "/picard-web/backups"
-
-# When loading new configuration (from options > maintenance),
-# picard will take a backup of the current configuration and try
-# to save it to /home/gwb/Documents, create a link to the backups
-# folder created above
-if [ ! -L "$GWB_HOME/Documents" ];then
-    if [ -d "$GWB_HOME/Documents" ]; then
-        rm -rf "$GWB_HOME/Documents"
-    fi
-    
-    ln -s /picard-web/backups $GWB_HOME/Documents
-fi
-
-# Link picard folder for persistence
-if [ ! -f /picard-web/MusicBrainz ]; then
-    create_directory_if_missing "$GWB_HOME/.config/MusicBrainz"
-    ln -s $GWB_HOME/.config/MusicBrainz /picard-web/MusicBrainz
-fi
+done
 
 exec /gwb/entrypoint.sh "$@"


### PR DESCRIPTION
# Picard Web

<div align="center">
  <img src="https://raw.githubusercontent.com/Aandree5/picard-web/refs/heads/main/images/logo_128.png" alt="Logo" />
  
  <b>Thank you for your contribution.  Please ensure your pull request meets the requirements in the checklist below.</b>
</div>

## Description
<!-- Concise description of what this PR does -->

## Checklist

- [ ] Docker image builds and runs successfully (`docker build`, `docker run`)
- [ ] Pre-commit hooks pass
- [ ] Docs updated (if applicable)

> Please aim to follow Conventional Commits for clarity and consistency, as this helps reviewers and future contributors understand changes at a glance. No worries if a few commits stray from the format, everything gets squashed when merged.

## Related Issues / PRs
<!-- Link to any related discussions -->
